### PR TITLE
Add Godot flashcard deckbuilder skeleton

### DIFF
--- a/autoload/Events.gd
+++ b/autoload/Events.gd
@@ -1,0 +1,6 @@
+extends Node
+class_name Events
+
+signal request_question(card, targets, stats)
+signal card_resolved(card)
+signal end_turn_requested()

--- a/characters/Enemy.gd
+++ b/characters/Enemy.gd
@@ -1,0 +1,13 @@
+extends Node
+class_name Enemy
+
+var hp: int = 30
+var block: int = 0
+
+func take_damage(amount: int) -> void:
+    var dmg := max(amount - block, 0)
+    block = max(block - amount, 0)
+    hp -= dmg
+
+func attack_player(player) -> void:
+    player.hp -= 4

--- a/characters/Enemy.tscn
+++ b/characters/Enemy.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource path="res://characters/Enemy.gd" type="Script" id=1]
+
+[node name="Enemy" type="Node"]
+script = ExtResource("1")

--- a/characters/Player.gd
+++ b/characters/Player.gd
@@ -1,0 +1,50 @@
+extends Node
+class_name Player
+
+var deck: Array = []
+var draw_pile: Array = []
+var discard_pile: Array = []
+var hand: Array = []
+var energy: int = 3
+var hp: int = 30
+
+const HAND_LIMIT := 10
+
+func build_starting_deck() -> void:
+    var loader := preload("res://data/question_loader.gd").new()
+    deck = loader.load_from_json("res://data/sample_questions.json")
+    draw_pile = deck.duplicate()
+    discard_pile.clear()
+    hand.clear()
+    energy = 3
+    randomize()
+
+func shuffle() -> void:
+    var n := draw_pile.size()
+    for i in range(n - 1, 0, -1):
+        var j := randi() % (i + 1)
+        var tmp = draw_pile[i]
+        draw_pile[i] = draw_pile[j]
+        draw_pile[j] = tmp
+
+func draw(n: int) -> void:
+    for i in range(n):
+        if hand.size() >= HAND_LIMIT:
+            return
+        if draw_pile.is_empty():
+            draw_pile = discard_pile
+            discard_pile = []
+            shuffle()
+            if draw_pile.is_empty():
+                return
+        var card = draw_pile.pop_back()
+        hand.append(card)
+
+func draw_up_to(limit: int) -> void:
+    var need := limit - hand.size()
+    if need > 0:
+        draw(need)
+
+func discard(card) -> void:
+    hand.erase(card)
+    discard_pile.append(card)

--- a/characters/Player.tscn
+++ b/characters/Player.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource path="res://characters/Player.gd" type="Script" id=1]
+
+[node name="Player" type="Node"]
+script = ExtResource("1")

--- a/custom_resources/card.gd
+++ b/custom_resources/card.gd
@@ -1,0 +1,7 @@
+extends Resource
+class_name Card
+
+@export var id: String = ""
+@export var title: String = ""
+@export var cost: int = 1
+@export var tags: PackedStringArray = []

--- a/custom_resources/question_card.gd
+++ b/custom_resources/question_card.gd
@@ -1,0 +1,15 @@
+extends Card
+class_name QuestionCard
+
+@export var question: String = ""
+@export var choices: PackedStringArray = PackedStringArray()
+@export var correct_index: int = 0
+@export_multiline var explanation: String = ""
+@export_range(1,3,1) var difficulty: int = 1
+
+var streak: int = 0
+var ease: float = 2.5
+var due_day: int = 0
+
+func play(targets: Array, char_stats: Node) -> void:
+    Events.request_question.emit(self, targets, char_stats)

--- a/data/question_loader.gd
+++ b/data/question_loader.gd
@@ -1,0 +1,22 @@
+extends Node
+class_name QuestionLoader
+
+func load_from_json(path: String) -> Array[QuestionCard]:
+    var cards: Array[QuestionCard] = []
+    var file := FileAccess.open(path, FileAccess.READ)
+    if file:
+        var text := file.get_as_text()
+        var data := JSON.parse_string(text)
+        if data is Array:
+            for item in data:
+                var card := QuestionCard.new()
+                card.id = item.get("id", "")
+                card.title = item.get("question", "")
+                card.question = item.get("question", "")
+                card.choices = PackedStringArray(item.get("choices", []))
+                card.correct_index = item.get("answer_index", 0)
+                card.explanation = item.get("explanation", "")
+                card.tags = PackedStringArray(item.get("tags", []))
+                card.difficulty = int(item.get("difficulty", 1))
+                cards.append(card)
+    return cards

--- a/data/sample_questions.json
+++ b/data/sample_questions.json
@@ -1,0 +1,25 @@
+[
+  {
+    "id": "phys_work_1",
+    "question": "Can work be negative?",
+    "choices": ["No","Yes, when force opposes displacement","Only in circular motion","Only at constant speed"],
+    "answer_index": 1,
+    "explanation": "W=F·d·cosθ; opposite directions → cosθ<0.",
+    "tags": ["Physics","Work"],
+    "difficulty": 1
+  },
+  {
+    "id": "towing_rigid_bar",
+    "question": "Why is a rigid tow bar better than a rope/chain, and which Newton’s law applies most?",
+    "choices": [
+      "Because bars are heavier; Newton’s 3rd",
+      "Smoother controlled force & can push; mainly Newton’s 2nd",
+      "Ropes reduce mass; Newton’s 1st",
+      "Bars increase friction; Newton’s 1st"
+    ],
+    "answer_index": 1,
+    "explanation": "Rigid bars avoid slack jerks and can transmit compression. F=ma → smooth a.",
+    "tags": ["Mechanics"],
+    "difficulty": 1
+  }
+]

--- a/project.godot
+++ b/project.godot
@@ -1,0 +1,6 @@
+[application]
+config/name="FlashcardDeckbuilder"
+run/main_scene="res://scenes/main/Main.tscn"
+
+[autoload]
+Events="*res://autoload/Events.gd"

--- a/scenes/battle/Battle.gd
+++ b/scenes/battle/Battle.gd
@@ -1,0 +1,37 @@
+extends Node
+class_name Battle
+
+@onready var player: Player = $Player
+@onready var enemy: Enemy = $Enemy
+@onready var ui: BattleUI = $CanvasLayer/BattleUI
+
+var wrong_answered: bool = false
+
+func _ready() -> void:
+    ui.battle = self
+    player.build_starting_deck()
+    player.shuffle()
+    player.draw(5)
+    ui.refresh()
+    Events.request_question.connect(_on_request_question)
+    Events.card_resolved.connect(_on_card_resolved)
+    Events.end_turn_requested.connect(_on_end_turn_requested)
+
+func register_answer(correct: bool) -> void:
+    if not correct:
+        wrong_answered = true
+
+func _on_request_question(card, targets, stats) -> void:
+    ui.show_question(card)
+
+func _on_card_resolved(card) -> void:
+    player.discard(card)
+    ui.refresh()
+
+func _on_end_turn_requested() -> void:
+    if wrong_answered:
+        enemy.attack_player(player)
+        wrong_answered = false
+    player.draw_up_to(5)
+    player.energy = 3
+    ui.refresh()

--- a/scenes/battle/Battle.tscn
+++ b/scenes/battle/Battle.tscn
@@ -1,0 +1,17 @@
+[gd_scene load_steps=5 format=3]
+
+[ext_resource path="res://characters/Player.tscn" type="PackedScene" id=1]
+[ext_resource path="res://characters/Enemy.tscn" type="PackedScene" id=2]
+[ext_resource path="res://scenes/ui/BattleUI.tscn" type="PackedScene" id=3]
+[ext_resource path="res://scenes/battle/Battle.gd" type="Script" id=4]
+
+[node name="Battle" type="Node"]
+script = ExtResource("4")
+
+[node name="Player" parent="." instance=ExtResource("1")]
+
+[node name="Enemy" parent="." instance=ExtResource("2")]
+
+[node name="CanvasLayer" type="CanvasLayer" parent="."]
+
+[node name="BattleUI" parent="CanvasLayer" instance=ExtResource("3")]

--- a/scenes/main/Main.gd
+++ b/scenes/main/Main.gd
@@ -1,0 +1,4 @@
+extends Node
+
+func _ready() -> void:
+    get_tree().change_scene_to_file("res://scenes/battle/Battle.tscn")

--- a/scenes/main/Main.tscn
+++ b/scenes/main/Main.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource path="res://scenes/main/Main.gd" type="Script" id=1]
+
+[node name="Main" type="Node"]
+script = ExtResource("1")

--- a/scenes/ui/BattleUI.gd
+++ b/scenes/ui/BattleUI.gd
@@ -1,0 +1,48 @@
+extends Control
+class_name BattleUI
+
+var battle: Battle
+
+@onready var player_label: Label = $TopBar/PlayerStats
+@onready var enemy_label: Label = $TopBar/EnemyStats
+@onready var hand_container: HBoxContainer = $Hand
+@onready var end_turn_button: Button = $EndTurn
+
+func _ready() -> void:
+    end_turn_button.pressed.connect(func(): Events.end_turn_requested.emit())
+
+func refresh() -> void:
+    update_stats()
+    refresh_hand()
+
+func update_stats() -> void:
+    if battle == null:
+        return
+    player_label.text = "HP: %d | EN: %d" % [battle.player.hp, battle.player.energy]
+    enemy_label.text = "Enemy HP: %d | BL: %d" % [battle.enemy.hp, battle.enemy.block]
+
+func refresh_hand() -> void:
+    for c in hand_container.get_children():
+        c.queue_free()
+    if battle == null:
+        return
+    var card_scene := preload("res://scenes/ui/CardUI.tscn")
+    for card in battle.player.hand:
+        var ui := card_scene.instantiate()
+        ui.setup(card, battle.player, [battle.enemy])
+        hand_container.add_child(ui)
+
+func show_question(card: QuestionCard) -> void:
+    var q_scene := preload("res://scenes/ui/QuestionUI.tscn")
+    var ui := q_scene.instantiate()
+    add_child(ui)
+    ui.show_question(card)
+    ui.answered.connect(func(correct: bool):
+        if correct:
+            battle.enemy.take_damage(5 + 3 * card.difficulty)
+        else:
+            battle.player.hp -= 3
+        battle.register_answer(correct)
+        ui.queue_free()
+        Events.card_resolved.emit(card)
+    )

--- a/scenes/ui/BattleUI.tscn
+++ b/scenes/ui/BattleUI.tscn
@@ -1,0 +1,33 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource path="res://scenes/ui/BattleUI.gd" type="Script" id=1]
+
+[node name="BattleUI" type="Control"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+script = ExtResource("1")
+
+[node name="TopBar" type="HBoxContainer" parent="."]
+anchor_right = 1.0
+[node name="PlayerStats" type="Label" parent="TopBar"]
+[node name="EnemyStats" type="Label" parent="TopBar"]
+
+[node name="Message" type="Label" parent="."]
+anchor_left = 0.3
+anchor_right = 0.7
+anchor_top = 0.3
+anchor_bottom = 0.4
+horizontal_alignment = 1
+
+[node name="Hand" type="HBoxContainer" parent="."]
+anchor_left = 0.0
+anchor_right = 1.0
+anchor_top = 0.6
+anchor_bottom = 0.9
+
+[node name="EndTurn" type="Button" parent="."]
+anchor_left = 0.8
+anchor_right = 0.95
+anchor_top = 0.9
+anchor_bottom = 0.98
+text = "End Turn"

--- a/scenes/ui/CardUI.gd
+++ b/scenes/ui/CardUI.gd
@@ -1,0 +1,28 @@
+extends Control
+class_name CardUI
+
+var card: Card
+var player
+var targets: Array = []
+
+@onready var title_label: Label = $Panel/VBoxContainer/Title
+@onready var preview_label: Label = $Panel/VBoxContainer/Preview
+@onready var cost_label: Label = $Panel/VBoxContainer/Cost
+
+func setup(c: Card, p, t: Array) -> void:
+    card = c
+    player = p
+    targets = t
+    title_label.text = card.title
+    if card is QuestionCard:
+        preview_label.text = card.question
+    else:
+        preview_label.text = ""
+    cost_label.text = "Cost: %d" % card.cost
+
+func _gui_input(event) -> void:
+    if event is InputEventMouseButton and event.pressed and event.button_index == MOUSE_BUTTON_LEFT:
+        if player.energy < card.cost:
+            return
+        player.energy -= card.cost
+        card.play(targets, player)

--- a/scenes/ui/CardUI.tscn
+++ b/scenes/ui/CardUI.tscn
@@ -1,0 +1,24 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource path="res://scenes/ui/CardUI.gd" type="Script" id=1]
+
+[node name="CardUI" type="Control"]
+custom_minimum_size = Vector2(220, 300)
+mouse_filter = 1
+script = ExtResource("1")
+
+[node name="Panel" type="Panel" parent="."]
+anchor_right = 1.0
+anchor_bottom = 1.0
+
+[node name="VBoxContainer" type="VBoxContainer" parent="Panel"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+
+[node name="Title" type="Label" parent="Panel/VBoxContainer"]
+wrap_mode = 2
+
+[node name="Preview" type="Label" parent="Panel/VBoxContainer"]
+wrap_mode = 2
+
+[node name="Cost" type="Label" parent="Panel/VBoxContainer"]

--- a/scenes/ui/QuestionUI.gd
+++ b/scenes/ui/QuestionUI.gd
@@ -1,0 +1,31 @@
+extends Control
+class_name QuestionUI
+
+signal answered(was_correct: bool)
+
+@onready var question_label: Label = $Panel/VBox/Question
+@onready var choices_container: VBoxContainer = $Panel/VBox/Choices
+@onready var explanation_label: Label = $Panel/VBox/Explanation
+@onready var continue_button: Button = $Panel/VBox/Continue
+
+var current_card: QuestionCard
+
+func show_question(card: QuestionCard) -> void:
+    current_card = card
+    question_label.text = card.question
+    explanation_label.text = card.explanation
+    explanation_label.visible = false
+    continue_button.disabled = true
+    for c in choices_container.get_children():
+        c.queue_free()
+    for i in card.choices.size():
+        var btn := Button.new()
+        btn.text = card.choices[i]
+        btn.pressed.connect(func(): _on_choice_selected(i))
+        choices_container.add_child(btn)
+
+func _on_choice_selected(index: int) -> void:
+    var correct := index == current_card.correct_index
+    explanation_label.visible = true
+    continue_button.disabled = false
+    continue_button.pressed.connect(func(): answered.emit(correct), CONNECT_ONESHOT)

--- a/scenes/ui/QuestionUI.tscn
+++ b/scenes/ui/QuestionUI.tscn
@@ -1,0 +1,36 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource path="res://scenes/ui/QuestionUI.gd" type="Script" id=1]
+
+[node name="QuestionUI" type="Control"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+script = ExtResource("1")
+
+[node name="ColorRect" type="ColorRect" parent="."]
+anchor_right = 1.0
+anchor_bottom = 1.0
+color = Color(0, 0, 0, 0.5)
+
+[node name="Panel" type="Panel" parent="."]
+anchor_left = 0.1
+anchor_top = 0.1
+anchor_right = 0.9
+anchor_bottom = 0.9
+
+[node name="VBox" type="VBoxContainer" parent="Panel"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+
+[node name="Question" type="Label" parent="Panel/VBox"]
+wrap_mode = 2
+
+[node name="Choices" type="VBoxContainer" parent="Panel/VBox"]
+
+[node name="Explanation" type="Label" parent="Panel/VBox"]
+visible = false
+wrap_mode = 2
+
+[node name="Continue" type="Button" parent="Panel/VBox"]
+text = "Continue"
+disabled = true


### PR DESCRIPTION
## Summary
- Add `Events` autoload for core signals
- Implement card and question card resources with play signaling
- Load questions from JSON into starting deck
- Create player, enemy, battle flow, and UI scenes including question modal
- Provide sample question data and project settings

## Testing
- `godot --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f373315788321bbde64a8cf017fc0